### PR TITLE
Extra Args property

### DIFF
--- a/CoreHtmlToImage/HtmlConverter.cs
+++ b/CoreHtmlToImage/HtmlConverter.cs
@@ -14,6 +14,8 @@ namespace CoreHtmlToImage
         private static string directory;
         private static string toolFilepath;
 
+        public string ExtraArgs = String.Empty;
+
         static HtmlConverter()
         {
             directory = AppContext.BaseDirectory;
@@ -109,6 +111,8 @@ namespace CoreHtmlToImage
             {
                 args = $"--quality {quality} --width {width} -f {imageFormat} {url} \"{filename}\"";
             }
+
+            args = string.Join(" ", ExtraArgs, args);
 
             Process process = Process.Start(new ProcessStartInfo(toolFilepath, args)
             {


### PR DESCRIPTION
Ability to avoid exception

```Failed to load about:blank, with network status code 301 and http status code 0 - Protocol "about" is unknown```

on Linux, just add `--enable-local-file-access` option, more details here https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4717 and here https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4536
(BREAKING CHANGE: block local filesystem access by default)